### PR TITLE
Fix Typo in HMTL options-header-content

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1496,7 +1496,7 @@ NEW OPTION: Option to change footer 1 and footer 2 columns (6, 4, 3, 2, 1).
 NEW OPTION: New grid option. Add to cart button below name/price.
 NEW OPTION: Boxed and Framed product grid style.
 NEW OPTION: Pinterest/Masonry Product grid option.
-NEW OPTION: Add HMTL or Shortcodes after a Blog post.
+NEW OPTION: Add HTML or Shortcodes after a Blog post.
 
 NEW: Flatsome Child Theme now has a custom function file.
 

--- a/inc/admin/options/header/options-header-content.php
+++ b/inc/admin/options/header/options-header-content.php
@@ -68,7 +68,7 @@ Flatsome_Option::add_field( 'option',  array(
 	'type'        => 'textarea',
 	'settings'     => 'nav_position_text_top',
 	'transport' => $transport,
-	'label'       => __( 'HMTL 4', 'flatsome-admin' ),
+	'label'       => __( 'HTML 4', 'flatsome-admin' ),
 	'description' => __( 'Add Any HTML or Shortcode here...', 'flatsome-admin' ),
 	'section'     => 'header_content',
 	'sanitize_callback' => 'flatsome_custom_sanitize',

--- a/inc/structure/structure-footer.php
+++ b/inc/structure/structure-footer.php
@@ -116,7 +116,7 @@ function flatsome_html_before_footer(){
 }
 add_action('flatsome_before_footer', 'flatsome_html_before_footer');
 
-// Custom HMTL After footer
+// Custom HTML After footer
 function flatsome_html_after_footer(){
 	$html_after = get_theme_mod('html_after_footer');
 	if($html_after){


### PR DESCRIPTION
I noticed that there is a slight 'HMTL' typo on the Header -> HTML page:

<img width="314" alt="Screenshot 2022-10-18 at 20 12 08" src="https://user-images.githubusercontent.com/13055416/196522605-bdcbbdff-1330-41d6-89c6-705b3e22ea6c.png">

This PR is a quick fix (it also fixes a couple of other Typos I noticed while searching).